### PR TITLE
fix(sabnzbd): remove nested /config/Downloads mount (v1.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.0.1] - 2026-01-05
+
+### Fixed
+- **SABnzbd**: Removed nested `/config/Downloads` mount in SABnzbd role
+  - Changed downloads mount from `/config/Downloads` to `/downloads`
+  - Ensures SABnzbd and *arr apps see downloads at consistent paths
+  - Prevents same nested mount issues that affected Sonarr/Radarr/Lidarr
+
 ## [1.0.0] - 2026-01-05
 
 ### Breaking Changes

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ authors:
 description: A collection of roles for running a media server in docker containers - sonarr, radarr, plex, ombi, transmission, etc
 license_file: LICENSE
 readme: README.md
-version: 1.0.0
+version: 1.0.1
 repository: https://github.com/compscidr/ansible-media-server
 tags:
   - docker

--- a/roles/sabnzbd/tasks/main.yml
+++ b/roles/sabnzbd/tasks/main.yml
@@ -18,7 +18,7 @@
     pull: true
     volumes:
       - "{{ sabnzbd_folder }}:/config:rw"
-      - "{{ sabnzbd_download_folder }}:/config/Downloads:rw"
+      - "{{ sabnzbd_download_folder }}:/downloads:rw"
     ports:
       - "{{ sabnzbd_port }}:8080"
     env:


### PR DESCRIPTION
## Summary
Completes the nested mount fixes from v1.0.0 by fixing SABnzbd role.

## Problem
SABnzbd had the same nested mount issue as Sonarr/Radarr/Lidarr:
- `/volume1/storage/downloads` mounted to `/config/Downloads` (nested under `/config`)
- This caused path mismatches with Sonarr/Radarr/Lidarr which now use `/downloads`

## Solution
- Changed SABnzbd downloads mount from `/config/Downloads` to `/downloads`
- Now all *arr apps and SABnzbd see downloads at consistent `/downloads` path
- Prevents potential SQLite database corruption issues

## Testing
- Verified mount structure no longer nests paths
- Ensures SABnzbd and *arr apps can find each other's downloads

## Version
Bumps collection version to `1.0.1` (patch release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)