### PR TITLE
feat: add shared Docker network for container name resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.3.0] - 2026-01-31
+
+### Added
+- **Shared Docker network**: Containers can now reach each other by name
+  - Set `media_storage_network_enabled: true` to enable
+  - Creates a `media` network (configurable via `media_storage_network_name`)
+  - All roles auto-join the network when enabled
+  - Allows `http://sonarr:8989`, `http://radarr:7878`, etc.
+
 ## [1.2.1] - 2026-01-31
 
 ### Fixed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ authors:
 description: A collection of roles for running a media server in docker containers - sonarr, radarr, plex, ombi, transmission, etc
 license_file: LICENSE
 readme: README.md
-version: 1.2.1
+version: 1.3.0
 repository: https://github.com/compscidr/ansible-media-server
 tags:
   - docker

--- a/roles/flaresolverr/defaults/main.yml
+++ b/roles/flaresolverr/defaults/main.yml
@@ -5,4 +5,4 @@ flaresolverr_tz: "America/Los_Angeles"
 flaresolverr_memory: "1g"
 
 # Docker network (use custom network for container name resolution)
-flaresolverr_networks: []
+flaresolverr_networks: "{{ [{'name': media_storage_network_name}] if media_storage_network_enabled | default(false) else [] }}"

--- a/roles/jackett/defaults/main.yml
+++ b/roles/jackett/defaults/main.yml
@@ -6,4 +6,4 @@ jackett_tz: "America/Los_Angeles"
 jackett_memory: "1g"
 
 # Docker network (use custom network for container name resolution)
-jackett_networks: []
+jackett_networks: "{{ [{'name': media_storage_network_name}] if media_storage_network_enabled | default(false) else [] }}"

--- a/roles/lidarr/defaults/main.yml
+++ b/roles/lidarr/defaults/main.yml
@@ -14,4 +14,4 @@ lidarr_memory: "1g"
 lidarr_memory_swap: "1g"
 
 # Docker network (use custom network for container name resolution)
-lidarr_networks: []
+lidarr_networks: "{{ [{'name': media_storage_network_name}] if media_storage_network_enabled | default(false) else [] }}"

--- a/roles/media_storage/defaults/main.yml
+++ b/roles/media_storage/defaults/main.yml
@@ -6,6 +6,12 @@
 # Base storage path - can be customized per deployment
 media_storage_base_path: /storage
 
+# Shared Docker network for container name resolution
+# Set to true to create a network and allow containers to reach each other by name
+# (e.g., http://sonarr:8989, http://radarr:7878)
+media_storage_network_enabled: false
+media_storage_network_name: "media"
+
 # Media directories to create
 # Note: transmission-openvpn uses /data/completed by default
 #       sabnzbd is user-configurable, often uses /downloads/complete

--- a/roles/media_storage/tasks/main.yml
+++ b/roles/media_storage/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: Create media network for container name resolution
+  tags: plex, transmission, sabnzbd, sonarr, radarr, lidarr, prowlarr, ombi, jackett, flaresolverr, slskd, soularr
+  become: true
+  community.docker.docker_network:
+    name: "{{ media_storage_network_name }}"
+    state: present
+  when: media_storage_network_enabled | default(false)
+
 - name: Create media folders
   tags: plex, transmission, sabnzbd, sonarr, radarr, lidarr
   become: true

--- a/roles/ombi/defaults/main.yml
+++ b/roles/ombi/defaults/main.yml
@@ -9,4 +9,4 @@ ombi_letsencrypt_email: ""
 ombi_memory: "1g"
 
 # Docker network (use custom network for container name resolution)
-ombi_networks: []
+ombi_networks: "{{ [{'name': media_storage_network_name}] if media_storage_network_enabled | default(false) else [] }}"

--- a/roles/plex/defaults/main.yml
+++ b/roles/plex/defaults/main.yml
@@ -23,4 +23,4 @@ plex_memory_swap: "1g"
 # Set to "bridge" for container name resolution, "host" for DLNA/discovery
 plex_network_mode: "bridge"
 # Custom networks (only used when plex_network_mode is "bridge")
-plex_networks: []
+plex_networks: "{{ [{'name': media_storage_network_name}] if media_storage_network_enabled | default(false) else [] }}"

--- a/roles/prowlarr/defaults/main.yml
+++ b/roles/prowlarr/defaults/main.yml
@@ -6,4 +6,4 @@ prowlarr_memory: "1g"
 prowlarr_memory_swap: "1g"
 
 # Docker network (use custom network for container name resolution)
-prowlarr_networks: []
+prowlarr_networks: "{{ [{'name': media_storage_network_name}] if media_storage_network_enabled | default(false) else [] }}"

--- a/roles/radarr/defaults/main.yml
+++ b/roles/radarr/defaults/main.yml
@@ -13,4 +13,4 @@ radarr_memory: "1g"
 radarr_memory_swap: "1g"
 
 # Docker network (use custom network for container name resolution)
-radarr_networks: []
+radarr_networks: "{{ [{'name': media_storage_network_name}] if media_storage_network_enabled | default(false) else [] }}"

--- a/roles/sabnzbd/defaults/main.yml
+++ b/roles/sabnzbd/defaults/main.yml
@@ -7,4 +7,4 @@ sabnzbd_memory: "1g"
 sabnzbd_memory_swap: "1g"
 
 # Docker network (use custom network for container name resolution)
-sabnzbd_networks: []
+sabnzbd_networks: "{{ [{'name': media_storage_network_name}] if media_storage_network_enabled | default(false) else [] }}"

--- a/roles/slskd/defaults/main.yml
+++ b/roles/slskd/defaults/main.yml
@@ -15,4 +15,4 @@ slskd_memory: "1g"
 slskd_memory_swap: "1g"
 
 # Docker network (use custom network for container name resolution)
-slskd_networks: []
+slskd_networks: "{{ [{'name': media_storage_network_name}] if media_storage_network_enabled | default(false) else [] }}"

--- a/roles/sonarr/defaults/main.yml
+++ b/roles/sonarr/defaults/main.yml
@@ -13,4 +13,4 @@ sonarr_memory: "1g"
 sonarr_memory_swap: "1g"
 
 # Docker network (use custom network for container name resolution)
-sonarr_networks: []
+sonarr_networks: "{{ [{'name': media_storage_network_name}] if media_storage_network_enabled | default(false) else [] }}"

--- a/roles/soularr/defaults/main.yml
+++ b/roles/soularr/defaults/main.yml
@@ -9,4 +9,4 @@ soularr_memory: "1g"
 soularr_memory_swap: "1g"
 
 # Docker network (use custom network for container name resolution)
-soularr_networks: []
+soularr_networks: "{{ [{'name': media_storage_network_name}] if media_storage_network_enabled | default(false) else [] }}"

--- a/roles/transmission/defaults/main.yml
+++ b/roles/transmission/defaults/main.yml
@@ -9,4 +9,4 @@ transmission_memory: "1g"
 transmission_memory_swap: "1g"
 
 # Docker network (use custom network for container name resolution)
-transmission_networks: []
+transmission_networks: "{{ [{'name': media_storage_network_name}] if media_storage_network_enabled | default(false) else [] }}"


### PR DESCRIPTION
Enables containers to reach each other by name (e.g., `http://sonarr:8989`, `http://radarr:7878`).

## Usage

```yaml
media_network_enabled: true
```

That's it! All containers will automatically join the `media` network.

## How it works

1. `media_storage` role creates the Docker network when `media_network_enabled: true`
2. All role defaults now auto-compute their `*_networks` variable:
   ```yaml
   sonarr_networks: "{{ [{'name': media_network_name}] if media_network_enabled | default(false) else [] }}"
   ```
3. Containers join the network automatically

## Changes

- `media_storage`: Added `media_network_enabled` and `media_network_name` variables
- All 12 roles: Updated `*_networks` defaults to auto-join when enabled

Bumps to 1.3.0