### PR TITLE
feat: add shm_size support for plex container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.3.1] - 2026-02-12
+
+### Added
+- **Plex**: Added `plex_shm_size` variable (default: "2g") to configure container shared memory
+  - Docker defaults `/dev/shm` to 64MB which is insufficient for Plex transcoding
+  - Prevents crashes and `.dmp` crash report generation during transcoding
+
 ## [1.3.0] - 2026-01-31
 
 ### Added

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ authors:
 description: A collection of roles for running a media server in docker containers - sonarr, radarr, plex, ombi, transmission, etc
 license_file: LICENSE
 readme: README.md
-version: 1.3.0
+version: 1.3.1
 repository: https://github.com/compscidr/ansible-media-server
 tags:
   - docker

--- a/roles/plex/defaults/main.yml
+++ b/roles/plex/defaults/main.yml
@@ -18,6 +18,7 @@ plex_dri_devices: false
 plex_claim: ""
 plex_memory: "1g"
 plex_memory_swap: "1g"
+plex_shm_size: "2g"
 
 # Docker networking
 # Set to "bridge" for container name resolution, "host" for DLNA/discovery

--- a/roles/plex/tasks/main.yml
+++ b/roles/plex/tasks/main.yml
@@ -51,3 +51,4 @@
     restart_policy: unless-stopped
     memory: "{{ plex_memory }}"
     memory_swap: "{{ plex_memory_swap }}"
+    shm_size: "{{ plex_shm_size }}"


### PR DESCRIPTION
## Summary
- Adds `plex_shm_size` variable (default `2g`) to the plex role
- Passes `shm_size` through to the `community.docker.docker_container` task
- Docker defaults `/dev/shm` to 64MB which is insufficient for Plex transcoding, causing crashes and generating `.dmp` crash reports

## Test plan
- [ ] Deploy plex with default `plex_shm_size` of `2g` and verify container starts
- [ ] Verify crash reports are no longer generated during transcoding
- [ ] Test overriding `plex_shm_size` with a custom value

🤖 Generated with [Claude Code](https://claude.com/claude-code)