### PR TITLE
feat: add reverse proxy support to radarr, sonarr, and plex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.4.0] - 2026-04-06
+
+### Added
+- **Radarr, Sonarr, Plex**: Added reverse proxy / SSL support via nginx-proxy and letsencrypt companion
+  - Added `*_virtual_host`, `*_virtual_port`, `*_letsencrypt_host`, and `*_letsencrypt_email` variables
+  - Matches the existing pattern used by the ombi role
+  - Defaults to empty strings for full backwards compatibility
+
 ## [1.3.2] - 2026-02-12
 
 ### Added

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ authors:
 description: A collection of roles for running a media server in docker containers - sonarr, radarr, plex, ombi, transmission, etc
 license_file: LICENSE
 readme: README.md
-version: 1.3.2
+version: 1.4.0
 repository: https://github.com/compscidr/ansible-media-server
 tags:
   - docker

--- a/roles/plex/defaults/main.yml
+++ b/roles/plex/defaults/main.yml
@@ -22,7 +22,7 @@ plex_shm_size: "2g"
 
 # Reverse proxy / SSL (nginx-proxy + letsencrypt companion)
 plex_virtual_host: ""
-plex_virtual_port: "{{ plex_port | string }}"
+plex_virtual_port: "32400"
 plex_letsencrypt_host: "{{ plex_virtual_host }}"
 plex_letsencrypt_email: ""
 

--- a/roles/plex/defaults/main.yml
+++ b/roles/plex/defaults/main.yml
@@ -20,6 +20,12 @@ plex_memory: "1g"
 plex_memory_swap: "1g"
 plex_shm_size: "2g"
 
+# Reverse proxy / SSL (nginx-proxy + letsencrypt companion)
+plex_virtual_host: ""
+plex_virtual_port: "{{ plex_port | string }}"
+plex_letsencrypt_host: "{{ plex_virtual_host }}"
+plex_letsencrypt_email: ""
+
 # Docker networking
 # Set to "bridge" for container name resolution, "host" for DLNA/discovery
 plex_network_mode: "bridge"

--- a/roles/plex/tasks/main.yml
+++ b/roles/plex/tasks/main.yml
@@ -47,6 +47,10 @@
       PUID: "{{ media_user_uid }}"
       PGID: "{{ media_user_gid }}"
       PLEX_CLAIM: "{{ plex_claim }}"
+      VIRTUAL_HOST: "{{ plex_virtual_host }}"
+      VIRTUAL_PORT: "{{ plex_virtual_port }}"
+      LETSENCRYPT_HOST: "{{ plex_letsencrypt_host }}"
+      LETSENCRYPT_EMAIL: "{{ plex_letsencrypt_email }}"
     networks: "{{ plex_networks if (plex_network_mode == 'bridge' and plex_networks | length > 0) else omit }}"
     restart_policy: unless-stopped
     memory: "{{ plex_memory }}"

--- a/roles/radarr/defaults/main.yml
+++ b/roles/radarr/defaults/main.yml
@@ -12,5 +12,11 @@ radarr_tz: "America/Los_Angeles"
 radarr_memory: "1g"
 radarr_memory_swap: "1g"
 
+# Reverse proxy / SSL (nginx-proxy + letsencrypt companion)
+radarr_virtual_host: ""
+radarr_virtual_port: "{{ radarr_port | string }}"
+radarr_letsencrypt_host: "{{ radarr_virtual_host }}"
+radarr_letsencrypt_email: ""
+
 # Docker network (use custom network for container name resolution)
 radarr_networks: "{{ [{'name': media_storage_network_name}] if media_storage_network_enabled | default(false) else [] }}"

--- a/roles/radarr/defaults/main.yml
+++ b/roles/radarr/defaults/main.yml
@@ -14,7 +14,7 @@ radarr_memory_swap: "1g"
 
 # Reverse proxy / SSL (nginx-proxy + letsencrypt companion)
 radarr_virtual_host: ""
-radarr_virtual_port: "{{ radarr_port | string }}"
+radarr_virtual_port: "7878"
 radarr_letsencrypt_host: "{{ radarr_virtual_host }}"
 radarr_letsencrypt_email: ""
 

--- a/roles/radarr/tasks/main.yml
+++ b/roles/radarr/tasks/main.yml
@@ -35,6 +35,10 @@
       TZ: "{{ radarr_tz }}"
       PUID: "{{ media_user_uid }}"
       PGID: "{{ media_user_gid }}"
+      VIRTUAL_HOST: "{{ radarr_virtual_host }}"
+      VIRTUAL_PORT: "{{ radarr_virtual_port }}"
+      LETSENCRYPT_HOST: "{{ radarr_letsencrypt_host }}"
+      LETSENCRYPT_EMAIL: "{{ radarr_letsencrypt_email }}"
     networks: "{{ radarr_networks if radarr_networks | length > 0 else omit }}"
     restart_policy: unless-stopped
     memory: "{{ radarr_memory }}"

--- a/roles/sonarr/defaults/main.yml
+++ b/roles/sonarr/defaults/main.yml
@@ -12,5 +12,11 @@ sonarr_tz: "America/Los_Angeles"
 sonarr_memory: "1g"
 sonarr_memory_swap: "1g"
 
+# Reverse proxy / SSL (nginx-proxy + letsencrypt companion)
+sonarr_virtual_host: ""
+sonarr_virtual_port: "{{ sonarr_port | string }}"
+sonarr_letsencrypt_host: "{{ sonarr_virtual_host }}"
+sonarr_letsencrypt_email: ""
+
 # Docker network (use custom network for container name resolution)
 sonarr_networks: "{{ [{'name': media_storage_network_name}] if media_storage_network_enabled | default(false) else [] }}"

--- a/roles/sonarr/defaults/main.yml
+++ b/roles/sonarr/defaults/main.yml
@@ -14,7 +14,7 @@ sonarr_memory_swap: "1g"
 
 # Reverse proxy / SSL (nginx-proxy + letsencrypt companion)
 sonarr_virtual_host: ""
-sonarr_virtual_port: "{{ sonarr_port | string }}"
+sonarr_virtual_port: "8989"
 sonarr_letsencrypt_host: "{{ sonarr_virtual_host }}"
 sonarr_letsencrypt_email: ""
 

--- a/roles/sonarr/tasks/main.yml
+++ b/roles/sonarr/tasks/main.yml
@@ -35,6 +35,10 @@
       TZ: "{{ sonarr_tz }}"
       PUID: "{{ media_user_uid }}"
       PGID: "{{ media_user_gid }}"
+      VIRTUAL_HOST: "{{ sonarr_virtual_host }}"
+      VIRTUAL_PORT: "{{ sonarr_virtual_port }}"
+      LETSENCRYPT_HOST: "{{ sonarr_letsencrypt_host }}"
+      LETSENCRYPT_EMAIL: "{{ sonarr_letsencrypt_email }}"
     networks: "{{ sonarr_networks if sonarr_networks | length > 0 else omit }}"
     restart_policy: unless-stopped
     memory: "{{ sonarr_memory }}"


### PR DESCRIPTION
## Summary
- Add `*_virtual_host`, `*_virtual_port`, `*_letsencrypt_host`, and `*_letsencrypt_email` variables to radarr, sonarr, and plex roles
- Matches the existing pattern used by the ombi role
- When set, these env vars enable auto-discovery by nginx-proxy and automatic SSL via letsencrypt companion
- Defaults to empty strings (no-op), so this is fully backwards compatible

Fixes #28

## Usage
```yaml
- name: Install radarr
  ansible.builtin.include_role:
    name: compscidr.media_server.radarr
  vars:
    radarr_virtual_host: "radarr.example.com"
    radarr_letsencrypt_email: "admin@example.com"
```

## Test plan
- [ ] Verify existing deployments without virtual_host vars are unaffected (env vars set to empty strings)
- [ ] Verify radarr/sonarr/plex with virtual_host vars are discovered by nginx-proxy
- [ ] Verify letsencrypt companion provisions SSL certs for configured hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)